### PR TITLE
Add AI Dev Jobs to AI section

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ This comprehensive collection features 700+ job boards across different categori
 - [AI Jobs](https://ai-jobs.net/)
 - [AiJobsTracker](https://www.aijobstracker.com/) | live aggregator of 300+ AI-first companies's job boards, updated daily.
 - [AI Tech Suite](https://www.aitechsuite.com/jobs) | AI tools and jobs aggregator with over 20k tools and 5k jobs, updated daily.
+- [AI Dev Jobs](https://aidevboard.com) | Free jobs board aggregating 5,400+ AI/ML/LLM roles from 55+ ATS sources. MCP server + REST API + RSS for agents. Free to search and apply.
 
 ## Data
 


### PR DESCRIPTION
Adds [AI Dev Jobs](https://aidevboard.com) to the AI section.

- Free jobs board aggregating 5,400+ AI/ML/LLM roles from 55+ ATS sources (Greenhouse, Lever, Ashby, etc.)
- MCP server at https://aidevboard.com/mcp — listed in the official MCP registry as `com.aidevboard/jobs`
- REST API at /api/v1/jobs (OpenAPI 3.0 spec)
- RSS feed at /feed.xml
- Free to search and apply for developers