### PR TITLE
Add usdevjobs.com to United_States

### DIFF
--- a/README.md
+++ b/README.md
@@ -460,6 +460,7 @@ This comprehensive collection features 700+ job boards across different categori
 - [Nexxt](https://www.nexxt.com/)
 - [National Labor Exchange](https://usnlx.com/)
 - [juju](https://www.juju.com/)
+- [usdevjobs](https://usdevjobs.com/) | Real-time job aggregator for software, AI/ML, and data roles from US startups.
 
 ## Argentina
 


### PR DESCRIPTION
Please Adds [US Dev Jobs](https://usdevjobs.com/) to the Job boards section.

- 1,000+ Software, AI/ML, Data engineering roles from US startups daily.
- The job list is updated hourly.
- Filter by remote , title, url, company.
- Aggregated only US jobs from Linkedin, Indeed, recruiting/staffing agencies.

Thank you for maintaining this list!