### PR TITLE
Add Hanzilla Jobs to Canada job boards

### DIFF
--- a/README.md
+++ b/README.md
@@ -512,6 +512,7 @@ This comprehensive collection features 700+ job boards across different categori
 - [jobgurus](https://ca.jobgurus.net/)
 - [betakit](https://betakit.com/jobs/) | Startup news site with a jobs board (Job board).
 - [Prospect](https://www.prospect.fyi/) | Career network built by-and-for the Canadian tech startup ecosystem (Job board).
+- [Hanzilla Jobs](https://jobs.hanzilla.co/) | Daily-updated Canadian student and recent-grad jobs board covering internships, co-ops, new grad, junior, and entry-level roles across tech, finance, engineering, business, sciences, and more (Job board).
 - [MaRS D - Work in Tech](https://www.marsdd.com/work-in-tech/community-job-board/) | Toronto's largest tech community hub, with links to other affiliated hubs in Canada (Job board).
 - [Workopolis](https://www.workopolis.com/en/) | Major job board and platform (Job board).
 - [Tech Ladies](https://www.hiretechladies.com/) | A worldwide community with 50,000 members offering a free job board, opportunities to learn, and career support for women in tech (Social network).


### PR DESCRIPTION
## Summary
- Adds Hanzilla Jobs to the Canada section.
- It is a daily-updated Canadian student/recent-grad jobs board covering internships, co-ops, new grad, junior, and entry-level roles across multiple fields.

## Verification
- Checked the live site and sitemap are available.
- README-only change.