### PR TITLE
Add Hanzilla Jobs to Canada job boards

### DIFF
--- a/README.md
+++ b/README.md
@@ -507,6 +507,7 @@ This comprehensive collection features 700+ job boards across different categori
 - [Jobboom](https://www.jobboom.com/en/job/)
 - [Jobillico](https://www.jobillico.com/search-jobs)
 - [Jobbank](https://www.jobbank.gc.ca/jobsearch/)
+- [Hanzilla Jobs](https://jobs.hanzilla.co/internships/) | Free daily-updated Canadian student and recent-grad jobs board for internships, co-ops, new grad, junior, and entry-level roles across tech, finance, engineering, business, and sciences (Job board).
 - [Eluta](https://www.eluta.ca/)
 - [CareerBeacon](https://www.careerbeacon.com/)
 - [jobgurus](https://ca.jobgurus.net/)


### PR DESCRIPTION
## Summary
- Add Hanzilla Jobs to the Canada section as a free daily-updated job board for Canadian students and recent grads.
- Link directly to the internships/co-ops landing page because it is the most relevant entry point for early-career users browsing job-board resources.

## Why
Hanzilla Jobs covers Canada-wide internships, co-ops, new grad, junior, and entry-level roles across tech, finance, engineering, business, and sciences, so it fits the Canada job-board list alongside Job Bank, Eluta, CareerBeacon, and Work in Tech.

## Test plan
- `git diff --check`
