### PR TITLE
Add EmbeddedJobs to Electronics and Hardware section

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ This comprehensive collection features 700+ job boards across different categori
 - [Startups](#startups)
 - [Free & Open Source](#open_source)
 - [DevOps](#devops)
+- [Electronics & Hardware](#embedded)
 - [World](#world)
   - [USA](#united_states)
   - [Australia](#australia)
@@ -446,6 +447,10 @@ This comprehensive collection features 700+ job boards across different categori
 - [JobDevOps](https://jobdevops.com)
 - [Kube Careers](https://kube.careers)
 - [NoFluffJobs](https://nofluffjobs.com/) | Job board for tech roles with clear job descriptions.
+
+## Electronics & Hardware
+
+- [EmbeddedJobs](https://embedded.jobs) | Job board dedicated to embedded systems engineering roles.
 
 ## World
 


### PR DESCRIPTION
**Add EmbeddedJobs to new Electronics & Hardware section**

Adds [EmbeddedJobs](https://embedded.jobs) — a job board dedicated to embedded systems engineering roles — and introduces a new Embedded & Hardware category to the list.

Changes:

Added Electronics & Hardware to the Table of Contents (after DevOps)
Created the ## Electronics and Hardware section between DevOps and World
Added EmbeddedJobs as the first entry in the new section

Why a new section?
Embedded systems engineering is a distinct discipline (firmware, RTOS, microcontrollers, hardware-software interfaces) that doesn't fit cleanly under Programming (which covers language/framework-specific boards) or any other existing category. This mirrors the pattern already used for other specialised engineering domains like DevOps and InfoSec.