### PR TITLE
docs: add Hanzilla Jobs to Canada job boards

### DIFF
--- a/README.md
+++ b/README.md
@@ -502,6 +502,7 @@ This comprehensive collection features 700+ job boards across different categori
 
 ### Canada
 
+- [Hanzilla Jobs](https://jobs.hanzilla.co/internships/) | Free daily-updated Canadian student and recent-grad job board for internships, co-ops, new-grad, junior, and entry-level roles across tech, engineering, business, finance, sciences, arts, and other fields (Job board).
 - [Work in Tech](https://www.workintech.ca/)
 - [Toronto Startup Jobs](https://to9to5.com/)
 - [Jobboom](https://www.jobboom.com/en/job/)


### PR DESCRIPTION
## Summary
- Adds Hanzilla Jobs to the Canada job boards section.
- Positions it as a free daily-updated Canadian student/recent-grad resource for internships, co-ops, new-grad, junior, and entry-level roles across fields.

## Why
This fits the Canada regional section and complements general Canadian job boards with a student/new-grad-focused option.

## Test plan
- Markdown-only change
- Ran `git diff --check`
