### PR TITLE
Add JobPin to Startups

### DIFF
--- a/README.md
+++ b/README.md
@@ -432,6 +432,7 @@ This comprehensive collection features 700+ job boards across different categori
 - [Y Combinator](https://ycombinator.com/) | Startup accelerator with job listings.
 - [StartupSucht](https://www.startupsucht.com/) | Job board focused on German startups.
 - [WorkAtAStartup](https://www.workatastartup.com/) | Job board for entry-level startup positions.
+- [JobPin](https://jobpin.com/) | Startup and technology jobs with company intelligence, aggregated from public company ATS pages and refreshed daily.
 
 ## Open_Source
 


### PR DESCRIPTION
### What this adds

Adds JobPin to the Startups section. JobPin is a startup and technology job directory that aggregates listings from public company ATS pages and links applicants to the original posting.

### Affiliation

I am submitting this on behalf of the JobPin project.

The homepage and description were checked before submission, and the repository did not already contain `jobpin.com`.