### PR TITLE
Add SwissAIJob to Switzerland section

### DIFF
--- a/README.md
+++ b/README.md
@@ -697,6 +697,7 @@ This comprehensive collection features 700+ job boards across different categori
 - [WeJob.ch](https://WeJob.ch/)
 - [Jobwinner](https://jobwinner.ch/en/)
 - [JobScout24](https://www.jobscout24.ch/en)
+- [SwissAIJob](https://swissaijob.ch/)
 
 ### Europe_Other
 


### PR DESCRIPTION
Adds [SwissAIJob](https://swissaijob.ch/) to the Switzerland section.

SwissAIJob is a job board aggregating AI/ML roles across Switzerland (academia, research institutes, and industry). It fills an AI/ML-specific niche alongside the existing Swiss general and dev-focused boards.