### PR TITLE
Add ChainJobs

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ This comprehensive collection features 700+ job boards across different categori
 ## Blockchain
 
 - [Blocktribe](https://blocktribe.com/)
+- [ChainJobs](https://chainjobs.io/) | 2,650+ live crypto & web3 jobs re-scraped daily from official ATS boards, with salary data.
 - [Crypto Jobs List](https://cryptojobslist.com/)
 - [CryptoJobs](https://crypto.jobs/)
 - [Blockew](https://blockew.com/)


### PR DESCRIPTION
Adding **ChainJobs** (https://chainjobs.io) — a crypto/web3 job board with a different source model from the boards already listed:

- 2,650+ live roles across 120 companies, re-scraped **daily from companies' own official ATS boards** (Greenhouse/Lever/Ashby) — no reposts; roles auto-expire when closed at the source
- 470+ roles with **employer-published salary bands** (medians/percentiles at /crypto-salaries/, nothing estimated)
- Free to browse, no signup wall; every listing links to the employer's own application page
- Free JSON API + RSS feeds
- Non-technical roles (marketing/BD/community/ops) surfaced alongside engineering

Link verified live; entry follows the list's format and position conventions. Happy to adjust wording.
