### PR TITLE
Add Jobless

### DIFF
--- a/README.md
+++ b/README.md
@@ -402,6 +402,7 @@ This comprehensive collection features 700+ job boards across different categori
 - [Christian Tech Jobs](https://www.christiantechjobs.io/)
 - [GreenLever](https://greenlever.co/)
 - [FindRemoteLawJobs](https://findremotelawjobs.com) | Remote Legal Jobs
+- [Jobless](https://jobless.dev/jobs) | 1M+ jobs aggregated from company career pages and ATS platforms, refreshed continuously with stale listings pruned
 
 ## Entry_Level
 


### PR DESCRIPTION
Jobless (https://jobless.dev) aggregates job postings from company career pages and ATS platforms (Greenhouse, Ashby, Lever, Workable, and others), with over 1M active listings and 75k+ posted in the last 7 days. Stale listings are pruned continuously.

Added to the Other section. I am the maintainer of the site.